### PR TITLE
[t137088] Fixes to the account_invoice_refund_reason

### DIFF
--- a/account_invoice_refund_reason/tests/test_account_invoice_refund_reason.py
+++ b/account_invoice_refund_reason/tests/test_account_invoice_refund_reason.py
@@ -3,10 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import datetime
 
-from odoo.tests.common import SavepointCase
+from odoo.tests.common import TransactionCase
 
 
-class TestAccountInvoiceRefundReason(SavepointCase):
+class TestAccountInvoiceRefundReason(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -75,7 +75,6 @@ class TestAccountInvoiceRefundReason(SavepointCase):
                 journal_id=self.account_invoice_customer0.journal_id.id,
             )
         )
-        self.account_invoice_refund_0._onchange_reason_id()
         self.assertEqual(
             self.account_invoice_refund_0.reason,
             self.account_invoice_refund_0.reason_id.name,

--- a/account_invoice_refund_reason/wizard/account_move_reversal.py
+++ b/account_invoice_refund_reason/wizard/account_move_reversal.py
@@ -8,13 +8,17 @@ class AccountMoveReversal(models.TransientModel):
     _inherit = "account.move.reversal"
 
     reason_id = fields.Many2one("account.move.refund.reason", string="Refund Reason")
+    reason = fields.Char(
+        compute="_compute_reason", precompute=True, store=True, readonly=False
+    )
 
-    @api.onchange("reason_id")
-    def _onchange_reason_id(self):
-        if self.reason_id:
-            self.reason = self.reason_id.name
+    @api.depends("reason_id")
+    def _compute_reason(self):
+        for record in self:
+            if record.reason_id:
+                record.reason = record.reason_id.name
 
     def reverse_moves(self):
         res = super().reverse_moves()
-        self.move_ids.mapped("reversal_move_id").write({"reason_id": self.reason_id})
+        self.move_ids.mapped("reversal_move_id").write({"reason_id": self.reason_id.id})
         return res


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=137088">[t137088] [MIG][16.0] gvfi_accounting_credit_note</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>account_invoice_refund_reason</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->