### PR TITLE
[bt#23172] Fix bug where some discounts weren't reset

### DIFF
--- a/account_invoice_triple_discount/models/account_move_line.py
+++ b/account_invoice_triple_discount/models/account_move_line.py
@@ -55,7 +55,7 @@ class AccountMoveLine(models.Model):
                 'id': record.id,
                 **old_values[index],
             }
-            if values.get('discount', False):
+            if 'discount' in values:
                 self.env.cr.execute(
                     'UPDATE account_move_line SET discount = %(discount)s WHERE id=%(id)s',
                     values,

--- a/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
+++ b/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
@@ -165,3 +165,28 @@ class TestInvoiceTripleDiscount(TransactionCase):
         invoice_form.save()
 
         self.assertEqual(invoice.amount_tax, 177.61)
+
+    def test_05_normal_discount_was_zero(self):
+        """
+        Tests the resetting of the normal discount.
+        """
+        invoice_form = Form(
+            self.AccountMove.with_context(
+                default_move_type="out_invoice",
+                default_journal_id=self.sale_journal.id,
+            )
+        )
+        invoice_form.partner_id = self.partner
+
+        with invoice_form.invoice_line_ids.new() as line_form:
+            line_form.name = "Line 1"
+            line_form.quantity = 10
+            line_form.price_unit = 1.0
+            line_form.discount = 0.0
+            line_form.discount2 = 15.0
+            line_form.tax_ids.clear()
+            line_form.tax_ids.add(self.tax)
+        invoice = invoice_form.save()
+
+        self.assertEqual(invoice.invoice_line_ids[0].discount, 0)
+        self.assertEqual(invoice.amount_tax, 1.28)

--- a/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
+++ b/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
@@ -188,5 +188,11 @@ class TestInvoiceTripleDiscount(TransactionCase):
             line_form.tax_ids.add(self.tax)
         invoice = invoice_form.save()
 
+        # All discounts are added and temporarily stored in
+        # `discount` to use Odoo's default discount calculation.
+        # Ensure that afterwards the original discount is set again.
         self.assertEqual(invoice.invoice_line_ids[0].discount, 0)
+        # Ensure that the tax calculation is correct and includes the
+        # discount.
+        # 10 units * 1 $/unit * (1 - 15% discount) * 15% tax = 1.28$
         self.assertEqual(invoice.amount_tax, 1.28)


### PR DESCRIPTION
If the original line has no discount, it was not reset to 0 properly after the calculation was done.

This adds a test that detects that case and a fix.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=helpdesk.ticket&id=23172">[bt#23172] WG: Fehler bei USt Berechnung</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>account_invoice_triple_discount</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->